### PR TITLE
[flyte-core] Create separate grpc service for flyteadmin

### DIFF
--- a/charts/flyte-core/templates/admin/service-grpc.yaml
+++ b/charts/flyte-core/templates/admin/service-grpc.yaml
@@ -2,15 +2,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "flyteadmin.name" . }}
+  name: {{ template "flyteadmin.name" . }}-grpc
   namespace: {{ template "flyte.namespace" . }}
   labels: {{ include "flyteadmin.labels" . | nindent 4 }}
   annotations:
     {{- if .Values.flyteadmin.service.annotations }}
     {{ tpl ( .Values.flyteadmin.service.annotations | toYaml ) . | nindent 4 }}
     {{- end }}
-    {{- if .Values.flyteadmin.service.httpAnnotations }}
-    {{ tpl ( .Values.flyteadmin.service.httpAnnotations | toYaml ) . | nindent 4 }}
+    {{- if .Values.flyteadmin.service.grpcAnnotations }}
+    {{ tpl ( .Values.flyteadmin.service.grpcAnnotations | toYaml ) . | nindent 4 }}
     {{- end }}
 spec:
   {{- with .Values.flyteadmin.service.type}}
@@ -21,16 +21,9 @@ spec:
     {{ . }}
   {{- end }}
   ports:
-    - name: http
-      port: 80
+    - name: grpc
+      port: 81
       protocol: TCP
-      targetPort: 8088
-    - name: redoc
-      protocol: TCP
-      port: 87
-      targetPort: 8087
-    - name: http-metrics
-      protocol: TCP
-      port: 10254
+      targetPort: 8089
   selector: {{ include "flyteadmin.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/flyte-core/templates/common/ingress.yaml
+++ b/charts/flyte-core/templates/common/ingress.yaml
@@ -8,84 +8,84 @@
   pathType: ImplementationSpecific
   backend:
     service:
-      name: flyteadmin
+      name: flyteadmin-grpc
       port:
         number: {{ $grpcPort }}
 - path: /flyteidl.service.SignalService/*
   pathType: ImplementationSpecific
   backend:
     service:
-      name: flyteadmin
+      name: flyteadmin-grpc
       port:
         number: {{ $grpcPort }}
 - path: /flyteidl.service.AdminService
   pathType: ImplementationSpecific
   backend:
     service:
-      name: flyteadmin
+      name: flyteadmin-grpc
       port:
         number: {{ $grpcPort }}
 - path: /flyteidl.service.AdminService/*
   pathType: ImplementationSpecific
   backend:
     service:
-      name: flyteadmin
+      name: flyteadmin-grpc
       port:
         number: {{ $grpcPort }}
 - path: /flyteidl.service.DataProxyService
   pathType: ImplementationSpecific
   backend:
     service:
-      name: flyteadmin
+      name: flyteadmin-grpc
       port:
         number: {{ $grpcPort }}
 - path: /flyteidl.service.DataProxyService/*
   pathType: ImplementationSpecific
   backend:
     service:
-      name: flyteadmin
+      name: flyteadmin-grpc
       port:
         number: {{ $grpcPort }}
 - path: /flyteidl.service.AuthMetadataService
   pathType: ImplementationSpecific
   backend:
     service:
-      name: flyteadmin
+      name: flyteadmin-grpc
       port:
         number: {{ $grpcPort }}
 - path: /flyteidl.service.AuthMetadataService/*
   pathType: ImplementationSpecific
   backend:
     service:
-      name: flyteadmin
+      name: flyteadmin-grpc
       port:
         number: {{ $grpcPort }}
 - path: /flyteidl.service.IdentityService
   pathType: ImplementationSpecific
   backend:
     service:
-      name: flyteadmin
+      name: flyteadmin-grpc
       port:
         number: {{ $grpcPort }}
 - path: /flyteidl.service.IdentityService/*
   pathType: ImplementationSpecific
   backend:
     service:
-      name: flyteadmin
+      name: flyteadmin-grpc
       port:
         number: {{ $grpcPort }}
 - path: /grpc.health.v1.Health
   pathType: ImplementationSpecific
   backend:
     service:
-      name: flyteadmin
+      name: flyteadmin-grpc
       port:
         number: {{ $grpcPort }}
 - path: /grpc.health.v1.Health/*
   pathType: ImplementationSpecific
   backend:
     service:
-      name: flyteadmin
+      name: flyteadmin-grpc
       port:
         number: {{ $grpcPort }}
   {{- end }}

--- a/charts/flyte-core/values-gcp.yaml
+++ b/charts/flyte-core/values-gcp.yaml
@@ -6,9 +6,9 @@ userSettings:
   dbHost: <CLOUD-SQL-IP>
   dbPassword: <DBPASSWORD>
 # These two storage buckets could be the same or you could specify different buckets if required. Both keys are required.
-# Learn more https://docs.flyte.org/en/latest/concepts/data_management.html#understand-how-flyte-handles-data 
-  bucketName: <METADATA_BUCKET_NAME> 
-  rawDataBucketName: <RAW_DATA_BUCKET_NAME> 
+# Learn more https://docs.flyte.org/en/latest/concepts/data_management.html#understand-how-flyte-handles-data
+  bucketName: <METADATA_BUCKET_NAME>
+  rawDataBucketName: <RAW_DATA_BUCKET_NAME>
   hostName: <HOSTNAME>
 
 #
@@ -35,7 +35,7 @@ flyteadmin:
       ephemeral-storage: 2Gi
       memory: 1G
   service:
-    annotations:
+    grpcAnnotations:
       # Required for the ingress to properly route grpc traffic to grpc port
       cloud.google.com/app-protocols: '{"grpc":"HTTP2"}'
   affinity:

--- a/charts/flyte-core/values-keycloak-idp-flyteclients-without-browser.yaml
+++ b/charts/flyte-core/values-keycloak-idp-flyteclients-without-browser.yaml
@@ -52,7 +52,7 @@ flyteadmin:
     - flyteexamples
   # -- Service settings for Flyteadmin
   service:
-    annotations:
+    grpcAnnotations:
       projectcontour.io/upstream-protocol.h2c: grpc
     type: ClusterIP
     loadBalancerSourceRanges: []

--- a/charts/flyte-core/values-sandbox.yaml
+++ b/charts/flyte-core/values-sandbox.yaml
@@ -3,7 +3,7 @@ flyteadmin:
   serviceMonitor:
     enabled: false
   service:
-    annotations:
+    grpcAnnotations:
       projectcontour.io/upstream-protocol.h2c: grpc
     type: ClusterIP
     loadBalancerSourceRanges: []

--- a/charts/flyte-core/values.yaml
+++ b/charts/flyte-core/values.yaml
@@ -50,8 +50,11 @@ flyteadmin:
     - flyteexamples
   # -- Service settings for Flyteadmin
   service:
-    annotations:
-      projectcontour.io/upstream-protocol.h2c: grpc
+    annotations: {}
+    httpAnnotations: {}
+    grpcAnnotations: {}
+      # projectcontour.io/upstream-protocol.h2c: grpc
+      # traefik.ingress.kubernetes.io/service.serversscheme: h2c
     type: ClusterIP
     loadBalancerSourceRanges: []
   # -- Configuration for service accounts for FlyteAdmin


### PR DESCRIPTION
## Tracking issue
_https://github.com/flyteorg/flyte/issues/4962_

## Why are the changes needed?

This allows setting annotations that are required for some ingress controllers for grpc communication only on parts that actually use grpc.
Without this separation, either the console or the grpc endpoints did not work properly with some ingress controllers, e.g. traefik.

## What changes were proposed in this pull request?

This PR splits the existing `flyteadmin` service of the `flyte-core` chart into two separate services (like in the `flyte-binary` chart).
One service for grpc communication and another one for all other communication.
Accordingly, the `annotations` field of the `values.yaml` was extended to also use `httpAnnotations` and `grpcAnnotations`.
Technically, this is a breaking change, because the `values.yaml` contained a default `annotation` (that I think should not really be there anyway):

```yaml
    annotations:
      projectcontour.io/upstream-protocol.h2c: grpc
```
I removed this default, but we could also keep this for backwards compatibility.

## Docs link

I'm not sure how to regenerate the docs for this chart from the `values.yaml`. Is there some command I can run?
